### PR TITLE
update: disable nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,10 @@ COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
 RUN npm run build
 
-######## Nginx setup ########
-FROM nginx:stable-alpine AS nginx
-COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/build /usr/share/nginx/html
+# ######## Nginx setup ########
+# FROM nginx:stable-alpine AS nginx
+# COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
+# COPY --from=build /app/build /usr/share/nginx/html
 
 ######## WebUI backend ########
 FROM python:3.11-slim-bookworm AS base

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,17 +21,17 @@ services:
     expose:
       - "8080"
 
-  nginx:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: nginx
-    container_name: nginx-webui
-    ports:
-      - "${OPEN_WEBUI_PORT}:80"
-    depends_on:
-      - open-webui
-    restart: unless-stopped
+  # nginx:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #     target: nginx
+  #   container_name: nginx-webui
+  #   ports:
+  #     - "${OPEN_WEBUI_PORT}:80"
+  #   depends_on:
+  #     - open-webui
+  #   restart: unless-stopped
 
 volumes:
   open-webui: {}


### PR DESCRIPTION
Disables the Nginx service in our Docker setup. The decision to remove Nginx from the Dockerfile and the `docker-compose.yaml` file is motivated by the need to simplify our deployment process and reduce resource consumption during development.

By disabling Nginx, we can focus on the core functionality of our application without the overhead of managing a separate web server. This change will streamline our local development environment and make it easier for developers to build and test the application without additional configuration.

In the future, we can consider reintroducing Nginx if needed, but for now, this update enhances the project's maintainability and development efficiency.