### PR TITLE
update: resize how to use tab

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -38,6 +38,10 @@
 	let dragged = false;
 
 	let minSize = 0;
+	let howToUseMinSize = 0;
+
+	// Calculate the appropriate minimum size based on whether HowToUse is shown
+	$: effectiveMinSize = $showHowToUse ? howToUseMinSize : minSize;
 
 	export const openPane = () => {
 		if (parseInt(localStorage?.chatControlsSize)) {
@@ -88,19 +92,24 @@
 
 		// initialize the minSize based on the container width
 		minSize = Math.floor((350 / container.clientWidth) * 100);
+		howToUseMinSize = Math.floor((410 / container.clientWidth) * 100);
 
 		// Create a new ResizeObserver instance
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (let entry of entries) {
 				const width = entry.contentRect.width;
-				// calculate the percentage of 200px
+				// calculate the percentage of 350px
 				const percentage = (350 / width) * 100;
 				// set the minSize to the percentage, must be an integer
 				minSize = Math.floor(percentage);
+				
+				// calculate the percentage for HowToUse (410px)
+				const howToUsePercentage = (410 / width) * 100;
+				howToUseMinSize = Math.floor(howToUsePercentage);
 
-				if ($showControls) {
-					if (pane && pane.isExpanded() && pane.getSize() < minSize) {
-						pane.resize(minSize);
+				if ($showControls || $showHowToUse) {
+					if (pane && pane.isExpanded() && pane.getSize() < effectiveMinSize) {
+						pane.resize(effectiveMinSize);
 					}
 				}
 			}
@@ -211,11 +220,14 @@
 				console.log('size', size, minSize);
 
 				if (($showControls || $showHowToUse) && pane.isExpanded()) {
-					if (size < minSize) {
-						pane.resize(minSize);
+					// Use 410px minimum width when $showHowToUse is true
+					const currentMinSize = $showHowToUse ? Math.floor((410 / document.getElementById('chat-container').clientWidth) * 100) : minSize;
+					
+					if (size < currentMinSize) {
+						pane.resize(currentMinSize);
 					}
 
-					if (size < minSize) {
+					if (size < currentMinSize) {
 						localStorage.chatControlsSize = 0;
 					} else {
 						localStorage.chatControlsSize = size;


### PR DESCRIPTION
### Pull Request Description: Update: Resize How to Use Tab

This pull request introduces changes to the `ChatControls.svelte` component to enhance the resizing behavior of the "How To Use" tab. The motivation behind this update is to improve user experience by ensuring that the tab displays correctly and maintains usability when shown alongside other controls.

#### Key Changes:
1. **Dynamic Minimum Size Calculation**: 
   - A new variable `howToUseMinSize` is introduced to calculate the appropriate minimum size for the "How To Use" section based on its visibility.
   - The effective minimum size for the pane is determined dynamically using a reactive statement, allowing for responsive adjustments based on the state of `$showHowToUse`.

2. **Improved Resize Logic**:
   - The resizing logic now accounts for both the controls and the "How To Use" section, ensuring that if either is visible, the pane resizes accordingly to a minimum width of 410px when the "How To Use" tab is active.

3. **Enhanced Responsiveness**:
   - The resizing behavior is refined to better accommodate different viewport sizes, enhancing the overall responsiveness of the chat interface.

#### Benefits:
- **Improved Usability**: Users will have a better experience with the chat interface as the "How To Use" tab will be properly sized, preventing any layout issues that could hinder interaction.
- **Dynamic Adaptability**: The component now adapts to various display sizes more effectively, promoting a consistent user experience across different devices.

This update ultimately contributes to a more polished and user-friendly chat interface, aligning with our goals of providing an intuitive and accessible application.