### PR TITLE
update: resize how to use tab

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -92,7 +92,7 @@
 
 		// initialize the minSize based on the container width
 		minSize = Math.floor((350 / container.clientWidth) * 100);
-		howToUseMinSize = Math.floor((410 / container.clientWidth) * 100);
+		howToUseMinSize = Math.floor((415 / container.clientWidth) * 100);
 
 		// Create a new ResizeObserver instance
 		const resizeObserver = new ResizeObserver((entries) => {
@@ -104,7 +104,7 @@
 				minSize = Math.floor(percentage);
 				
 				// calculate the percentage for HowToUse (410px)
-				const howToUsePercentage = (410 / width) * 100;
+				const howToUsePercentage = (415 / width) * 100;
 				howToUseMinSize = Math.floor(howToUsePercentage);
 
 				if ($showControls || $showHowToUse) {
@@ -221,7 +221,7 @@
 
 				if (($showControls || $showHowToUse) && pane.isExpanded()) {
 					// Use 410px minimum width when $showHowToUse is true
-					const currentMinSize = $showHowToUse ? Math.floor((410 / document.getElementById('chat-container').clientWidth) * 100) : minSize;
+					const currentMinSize = $showHowToUse ? Math.floor((415 / document.getElementById('chat-container').clientWidth) * 100) : minSize;
 					
 					if (size < currentMinSize) {
 						pane.resize(currentMinSize);


### PR DESCRIPTION
### Pull Request Description: Update: Resize How to Use Tab

This pull request updates the minimum size calculations for the "How to Use" tab within the chat controls component. The adjustments change the base width from 410px to 415px, ensuring that the tab content displays correctly and maintains optimal usability across different screen sizes.

#### Motivation:
The original minimum size of 410px was insufficient for certain content layouts, leading to potential clipping or overflow issues. By increasing the minimum size to 415px, we aim to enhance the visual presentation and user experience of the chat controls.

#### Improvements:
- **User Experience**: Ensures that all content within the "How to Use" tab is fully visible and accessible, reducing the risk of user frustration due to hidden or cut-off elements.
- **Responsiveness**: The updated calculations improve the responsiveness of the chat controls, especially in varying screen widths, leading to a more polished and professional interface.

This change is a small but impactful enhancement that contributes to the overall quality and usability of the chat component.