### PR TITLE
FIX: apply prelude only to model with knowledge

### DIFF
--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -25,6 +25,7 @@ from open_webui.functions import generate_function_chat_completion
 
 from open_webui.routers.openai import (
     generate_chat_completion as generate_openai_chat_completion,
+    generate_chat_completion_with_prelude as generate_openai_chat_completion_with_prelude,
 )
 
 from open_webui.routers.ollama import (
@@ -272,12 +273,21 @@ async def generate_chat_completion(
             else:
                 return convert_response_ollama_to_openai(response)
         else:
-            return await generate_openai_chat_completion(
-                request=request,
-                form_data=form_data,
-                user=user,
-                bypass_filter=bypass_filter,
-            )
+            model_knowledge = model.get("info", {}).get("meta", {}).get("knowledge", False)
+            if model_knowledge:
+                return await generate_openai_chat_completion_with_prelude(
+                    request=request,
+                    form_data=form_data,
+                    user=user,
+                    bypass_filter=bypass_filter,
+                )
+            else:
+                return await generate_openai_chat_completion(
+                    request=request,
+                    form_data=form_data,
+                    user=user,
+                    bypass_filter=bypass_filter,
+                )
 
 
 chat_completion = generate_chat_completion


### PR DESCRIPTION
### Pull Request Description: FIX: apply prelude only to models with knowledge

#### Motivation:
The purpose of this change is to enhance the user experience by ensuring that the prelude is only applied to models that possess knowledge capabilities. Previously, the prelude was applied indiscriminately, which could lead to confusion or irrelevant context for users interacting with models that do not support knowledge features.

#### Changes Made:
1. **Conditional Prelude Application**: Implemented logic to check if the model has knowledge capabilities before applying the prelude. This is done in the `generate_chat_completion_with_prelude` function, where the model's metadata is examined.
  
2. **Streamlined Error Handling**: Improved error handling for API requests and responses, ensuring that users receive appropriate feedback when a model is not found or when access is denied.

3. **Code Organization**: Refactored the streaming logic to maintain clarity and ensure that the response handling is efficient.

#### Benefits:
- **Improved User Experience**: By applying the prelude only to suitable models, users will receive more relevant and context-aware responses, leading to better engagement and satisfaction.
  
- **Error Reduction**: The changes reduce the likelihood of errors arising from applying the prelude to models that do not support it, improving the overall robustness of the application.

- **Maintainability**: The refactored code is cleaner and more organized, making it easier for future developers to understand and maintain.

This change not only resolves the immediate issue but also lays the groundwork for a more adaptive and user-friendly interaction with our AI models.